### PR TITLE
Add continue flag to wget downloads

### DIFF
--- a/download.bash
+++ b/download.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-wget --timestamping --output-document=models/disparity-estimation.pytorch http://content.sniklaus.com/kenburns/network-disparity.pytorch
-wget --timestamping --output-document=models/disparity-refinement.pytorch http://content.sniklaus.com/kenburns/network-refinement.pytorch
-wget --timestamping --output-document=models/pointcloud-inpainting.pytorch http://content.sniklaus.com/kenburns/network-inpainting.pytorch
+wget --continue --timestamping --output-document=models/disparity-estimation.pytorch http://content.sniklaus.com/kenburns/network-disparity.pytorch
+wget --continue --timestamping --output-document=models/disparity-refinement.pytorch http://content.sniklaus.com/kenburns/network-refinement.pytorch
+wget --continue --timestamping --output-document=models/pointcloud-inpainting.pytorch http://content.sniklaus.com/kenburns/network-inpainting.pytorch


### PR DESCRIPTION
I'm currently with a low bandwidth internet and having trouble downloading the weights. Adding the `--continue` flag to `wget` resumes the dowload from the partially downloaded file.